### PR TITLE
Use Game Pointer class for Joystick object controls

### DIFF
--- a/src/models/game-pointer.ts
+++ b/src/models/game-pointer.ts
@@ -3,6 +3,8 @@ export type PointerType = "mouse" | "touch" | "pen";
 export class GamePointer {
   private x: number = 0;
   private y: number = 0;
+  private initialX: number = 0;
+  private initialY: number = 0;
 
   private type: PointerType = "mouse";
 
@@ -17,12 +19,28 @@ export class GamePointer {
     return this.y;
   }
 
+  public getInitialX(): number {
+    return this.initialX;
+  }
+
+  public getInitialY(): number {
+    return this.initialY;
+  }
+
   public setX(x: number): void {
     this.x = x;
   }
 
   public setY(y: number): void {
     this.y = y;
+  }
+
+  public setInitialX(x: number): void {
+    this.initialX = x;
+  }
+
+  public setInitialY(y: number): void {
+    this.initialY = y;
   }
 
   public isPressing(): boolean {
@@ -52,6 +70,8 @@ export class GamePointer {
   public reset(): void {
     this.x = -1;
     this.y = -1;
+    this.initialX = -1;
+    this.initialY = -1;
     this.pressing = false;
     this.pressed = false;
   }

--- a/src/models/game-pointer.ts
+++ b/src/models/game-pointer.ts
@@ -67,6 +67,10 @@ export class GamePointer {
     this.type = type;
   }
 
+  public isTouch(): boolean {
+    return this.type === "touch";
+  }
+
   public reset(): void {
     this.x = -1;
     this.y = -1;

--- a/src/objects/joystick-object.ts
+++ b/src/objects/joystick-object.ts
@@ -12,24 +12,34 @@ export class JoystickObject extends BaseGameObject {
   private x: number = 0;
   private y: number = 0;
 
-  private usingTouch: boolean = false;
-
   private pressedKeys: Set<string> = new Set();
 
-  constructor(private readonly canvas: HTMLCanvasElement, private readonly gamePointer: GamePointer) {
+  constructor(
+    private readonly canvas: HTMLCanvasElement,
+    private readonly gamePointer: GamePointer
+  ) {
     super();
     this.addKeyboardEventListeners();
   }
 
   public update(deltaTimeStamp: DOMHighResTimeStamp) {
-    if (this.usingTouch) {
+    if (this.gamePointer.isTouch()) {
+      this.handleGamePointerEvents();
       this.updateJoystickPosition();
     }
   }
 
   public render(context: CanvasRenderingContext2D) {
-    if (this.usingTouch) {
+    if (this.gamePointer.isTouch() && this.gamePointer.isPressing()) {
       this.drawJoystick(context);
+    }
+  }
+
+  private handleGamePointerEvents() {
+    if (this.gamePointer.isPressing()) {
+      this.active = true;
+    } else {
+      this.resetJoystick();
     }
   }
 
@@ -49,17 +59,19 @@ export class JoystickObject extends BaseGameObject {
   private calculateDistance(): number {
     return Math.sqrt(
       Math.pow(this.gamePointer.getX() - this.gamePointer.getInitialX(), 2) +
-        Math.pow(this.gamePointer.getY() - this.gamePointer.getInitialY(), 2),
+        Math.pow(this.gamePointer.getY() - this.gamePointer.getInitialY(), 2)
     );
   }
 
   private adjustPosition() {
     const angle = Math.atan2(
       this.gamePointer.getY() - this.gamePointer.getInitialY(),
-      this.gamePointer.getX() - this.gamePointer.getInitialX(),
+      this.gamePointer.getX() - this.gamePointer.getInitialX()
     );
-    const newX = this.gamePointer.getInitialX() + this.MAX_DISTANCE * Math.cos(angle);
-    const newY = this.gamePointer.getInitialY() + this.MAX_DISTANCE * Math.sin(angle);
+    const newX =
+      this.gamePointer.getInitialX() + this.MAX_DISTANCE * Math.cos(angle);
+    const newY =
+      this.gamePointer.getInitialY() + this.MAX_DISTANCE * Math.sin(angle);
     this.x = newX;
     this.y = newY;
   }
@@ -96,7 +108,7 @@ export class JoystickObject extends BaseGameObject {
       this.gamePointer.getInitialY(),
       this.RADIUS,
       0,
-      Math.PI * 2,
+      Math.PI * 2
     );
     context.strokeStyle = "rgba(0, 0, 0, 0.2)";
     context.lineWidth = 2; // Adjust line width as needed
@@ -113,7 +125,7 @@ export class JoystickObject extends BaseGameObject {
       0,
       this.x,
       this.y,
-      this.RADIUS,
+      this.RADIUS
     );
     gradient.addColorStop(0, "rgba(0, 0, 0, 0.8)");
     gradient.addColorStop(1, "rgba(50, 50, 50, 0.8)");
@@ -152,14 +164,14 @@ export class JoystickObject extends BaseGameObject {
   }
 
   private updateControlValues() {
-    const isArrowUpPressed = this.pressedKeys.has("ArrowUp") ||
-      this.pressedKeys.has("w");
-    const isArrowDownPressed = this.pressedKeys.has("ArrowDown") ||
-      this.pressedKeys.has("s");
-    const isArrowLeftPressed = this.pressedKeys.has("ArrowLeft") ||
-      this.pressedKeys.has("a");
-    const isArrowRightPressed = this.pressedKeys.has("ArrowRight") ||
-      this.pressedKeys.has("d");
+    const isArrowUpPressed =
+      this.pressedKeys.has("ArrowUp") || this.pressedKeys.has("w");
+    const isArrowDownPressed =
+      this.pressedKeys.has("ArrowDown") || this.pressedKeys.has("s");
+    const isArrowLeftPressed =
+      this.pressedKeys.has("ArrowLeft") || this.pressedKeys.has("a");
+    const isArrowRightPressed =
+      this.pressedKeys.has("ArrowRight") || this.pressedKeys.has("d");
 
     this.active = isArrowUpPressed || isArrowDownPressed;
 
@@ -182,7 +194,6 @@ export class JoystickObject extends BaseGameObject {
 
   private resetJoystick() {
     this.active = false;
-    this.usingTouch = false;
     this.controlX = 0;
     this.controlY = 0;
   }

--- a/src/objects/local-car-object.ts
+++ b/src/objects/local-car-object.ts
@@ -1,3 +1,4 @@
+import { GamePointer } from "../models/game-pointer.js";
 import { CarObject } from "./car-object.js";
 import { GearStickObject } from "./gear-stick-object.js";
 import { JoystickObject } from "./joystick-object.js";
@@ -6,9 +7,15 @@ export class LocalCarObject extends CarObject {
   private readonly joystickObject: JoystickObject;
   private readonly gearStickObject: GearStickObject;
 
-  constructor(x: number, y: number, angle: number, canvas: HTMLCanvasElement) {
+  constructor(
+    x: number,
+    y: number,
+    angle: number,
+    canvas: HTMLCanvasElement,
+    gamePointer: GamePointer
+  ) {
     super(x, y, angle, false, canvas);
-    this.joystickObject = new JoystickObject(canvas);
+    this.joystickObject = new JoystickObject(canvas, gamePointer);
     this.gearStickObject = new GearStickObject(canvas);
   }
 
@@ -47,7 +54,8 @@ export class LocalCarObject extends CarObject {
       }
     }
 
-    this.angle += this.HANDLING *
+    this.angle +=
+      this.HANDLING *
       (this.speed / this.TOP_SPEED) *
       this.joystickObject.getControlX();
   }

--- a/src/screens/base/base-colliding-game-screen.ts
+++ b/src/screens/base/base-colliding-game-screen.ts
@@ -5,7 +5,7 @@ import { HitboxObject } from "../../objects/common/hitbox-object.js";
 import { GameController } from "../../models/game-controller.js";
 
 export class BaseCollidingGameScreen extends BaseGameScreen {
-  constructor(gameController: GameController) {
+  constructor(protected gameController: GameController) {
     super(gameController);
   }
 

--- a/src/screens/world-screen.ts
+++ b/src/screens/world-screen.ts
@@ -18,7 +18,7 @@ export class WorldScreen extends BaseCollidingGameScreen {
   private orangeGoalObject: GoalObject | null = null;
   private blueGoalObject: GoalObject | null = null;
 
-  constructor(gameController: GameController) {
+  constructor(protected gameController: GameController) {
     super(gameController);
     this.gameState = gameController.getGameState();
   }
@@ -69,9 +69,17 @@ export class WorldScreen extends BaseCollidingGameScreen {
   }
 
   private createPlayerAndLocalCarObjects() {
+    const gamePointer = this.gameController.getGamePointer();
     const playerObject = this.createAndGetPlayerObject();
 
-    const localCarObject = new LocalCarObject(0, 0, 90, this.canvas);
+    const localCarObject = new LocalCarObject(
+      0,
+      0,
+      90,
+      this.canvas,
+      gamePointer
+    );
+
     localCarObject.setCenterPosition();
     localCarObject.setPlayerObject(playerObject);
 

--- a/src/services/game-loop-service.ts
+++ b/src/services/game-loop-service.ts
@@ -58,7 +58,7 @@ export class GameLoopService {
     console.info(
       "%cDebug mode on",
       "color: #b6ff35; font-size: 20px; font-weight: bold"
-    );ñ
+    );
   }
 
   private setCanvasSize(): void {

--- a/src/services/game-loop-service.ts
+++ b/src/services/game-loop-service.ts
@@ -161,6 +161,8 @@ export class GameLoopService {
     this.gameFrame.getCurrentScreen()?.update(deltaTimeStamp);
     this.gameFrame.getNextScreen()?.update(deltaTimeStamp);
     this.gameFrame.getNotificationObject()?.update(deltaTimeStamp);
+
+    this.gamePointer.setPressed(false);
   }
 
   private render(): void {

--- a/src/services/game-loop-service.ts
+++ b/src/services/game-loop-service.ts
@@ -58,7 +58,7 @@ export class GameLoopService {
     console.info(
       "%cDebug mode on",
       "color: #b6ff35; font-size: 20px; font-weight: bold"
-    );
+    );ñ
   }
 
   private setCanvasSize(): void {
@@ -89,6 +89,8 @@ export class GameLoopService {
       this.gamePointer.setType(event.pointerType as PointerType);
       this.gamePointer.setX(event.clientX);
       this.gamePointer.setY(event.clientY);
+      this.gamePointer.setInitialX(event.clientX);
+      this.gamePointer.setInitialY(event.clientY);
       this.gamePointer.setPressing(true);
     });
 

--- a/static/js/models/game-pointer.js
+++ b/static/js/models/game-pointer.js
@@ -1,6 +1,8 @@
 export class GamePointer {
     x = 0;
     y = 0;
+    initialX = 0;
+    initialY = 0;
     type = "mouse";
     pressing = false;
     pressed = false;
@@ -10,11 +12,23 @@ export class GamePointer {
     getY() {
         return this.y;
     }
+    getInitialX() {
+        return this.initialX;
+    }
+    getInitialY() {
+        return this.initialY;
+    }
     setX(x) {
         this.x = x;
     }
     setY(y) {
         this.y = y;
+    }
+    setInitialX(x) {
+        this.initialX = x;
+    }
+    setInitialY(y) {
+        this.initialY = y;
     }
     isPressing() {
         return this.pressing;
@@ -37,6 +51,8 @@ export class GamePointer {
     reset() {
         this.x = -1;
         this.y = -1;
+        this.initialX = -1;
+        this.initialY = -1;
         this.pressing = false;
         this.pressed = false;
     }

--- a/static/js/models/game-pointer.js
+++ b/static/js/models/game-pointer.js
@@ -48,6 +48,9 @@ export class GamePointer {
     setType(type) {
         this.type = type;
     }
+    isTouch() {
+        return this.type === "touch";
+    }
     reset() {
         this.x = -1;
         this.y = -1;

--- a/static/js/objects/joystick-object.js
+++ b/static/js/objects/joystick-object.js
@@ -9,7 +9,6 @@ export class JoystickObject extends BaseGameObject {
     controlY = 0;
     x = 0;
     y = 0;
-    usingTouch = false;
     pressedKeys = new Set();
     constructor(canvas, gamePointer) {
         super();
@@ -18,13 +17,22 @@ export class JoystickObject extends BaseGameObject {
         this.addKeyboardEventListeners();
     }
     update(deltaTimeStamp) {
-        if (this.usingTouch) {
+        if (this.gamePointer.isTouch()) {
+            this.handleGamePointerEvents();
             this.updateJoystickPosition();
         }
     }
     render(context) {
-        if (this.usingTouch) {
+        if (this.gamePointer.isTouch() && this.gamePointer.isPressing()) {
             this.drawJoystick(context);
+        }
+    }
+    handleGamePointerEvents() {
+        if (this.gamePointer.isPressing()) {
+            this.active = true;
+        }
+        else {
+            this.resetJoystick();
         }
     }
     updateJoystickPosition() {
@@ -106,14 +114,10 @@ export class JoystickObject extends BaseGameObject {
         this.updateControlValues();
     }
     updateControlValues() {
-        const isArrowUpPressed = this.pressedKeys.has("ArrowUp") ||
-            this.pressedKeys.has("w");
-        const isArrowDownPressed = this.pressedKeys.has("ArrowDown") ||
-            this.pressedKeys.has("s");
-        const isArrowLeftPressed = this.pressedKeys.has("ArrowLeft") ||
-            this.pressedKeys.has("a");
-        const isArrowRightPressed = this.pressedKeys.has("ArrowRight") ||
-            this.pressedKeys.has("d");
+        const isArrowUpPressed = this.pressedKeys.has("ArrowUp") || this.pressedKeys.has("w");
+        const isArrowDownPressed = this.pressedKeys.has("ArrowDown") || this.pressedKeys.has("s");
+        const isArrowLeftPressed = this.pressedKeys.has("ArrowLeft") || this.pressedKeys.has("a");
+        const isArrowRightPressed = this.pressedKeys.has("ArrowRight") || this.pressedKeys.has("d");
         this.active = isArrowUpPressed || isArrowDownPressed;
         if (isArrowUpPressed && !isArrowDownPressed) {
             this.controlY = -1;
@@ -136,7 +140,6 @@ export class JoystickObject extends BaseGameObject {
     }
     resetJoystick() {
         this.active = false;
-        this.usingTouch = false;
         this.controlX = 0;
         this.controlY = 0;
     }

--- a/static/js/objects/local-car-object.js
+++ b/static/js/objects/local-car-object.js
@@ -4,9 +4,9 @@ import { JoystickObject } from "./joystick-object.js";
 export class LocalCarObject extends CarObject {
     joystickObject;
     gearStickObject;
-    constructor(x, y, angle, canvas) {
+    constructor(x, y, angle, canvas, gamePointer) {
         super(x, y, angle, false, canvas);
-        this.joystickObject = new JoystickObject(canvas);
+        this.joystickObject = new JoystickObject(canvas, gamePointer);
         this.gearStickObject = new GearStickObject(canvas);
     }
     update(deltaTimeStamp) {
@@ -37,8 +37,9 @@ export class LocalCarObject extends CarObject {
                 this.speed -= this.ACCELERATION;
             }
         }
-        this.angle += this.HANDLING *
-            (this.speed / this.TOP_SPEED) *
-            this.joystickObject.getControlX();
+        this.angle +=
+            this.HANDLING *
+                (this.speed / this.TOP_SPEED) *
+                this.joystickObject.getControlX();
     }
 }

--- a/static/js/screens/base/base-colliding-game-screen.js
+++ b/static/js/screens/base/base-colliding-game-screen.js
@@ -2,8 +2,10 @@ import { BaseGameScreen } from "./base-game-screen.js";
 import { BaseStaticCollidableGameObject as BaseStaticCollidableGameObject } from "../../objects/base/base-static-collidable-game-object.js";
 import { BaseDynamicCollidableGameObject } from "../../objects/base/base-collidable-dynamic-game-object.js";
 export class BaseCollidingGameScreen extends BaseGameScreen {
+    gameController;
     constructor(gameController) {
         super(gameController);
+        this.gameController = gameController;
     }
     update(deltaTimeStamp) {
         super.update(deltaTimeStamp);

--- a/static/js/screens/world-screen.js
+++ b/static/js/screens/world-screen.js
@@ -8,6 +8,7 @@ import { getConfigurationKey } from "../utils/configuration-utils.js";
 import { SCOREBOARD_SECONDS_DURATION } from "../constants/configuration-constants.js";
 import { LocalPlayerObject } from "../objects/local-player-object.js";
 export class WorldScreen extends BaseCollidingGameScreen {
+    gameController;
     gameState;
     scoreboardObject = null;
     ballObject = null;
@@ -15,6 +16,7 @@ export class WorldScreen extends BaseCollidingGameScreen {
     blueGoalObject = null;
     constructor(gameController) {
         super(gameController);
+        this.gameController = gameController;
         this.gameState = gameController.getGameState();
     }
     loadObjects() {
@@ -50,8 +52,9 @@ export class WorldScreen extends BaseCollidingGameScreen {
         this.sceneObjects.push(this.blueGoalObject);
     }
     createPlayerAndLocalCarObjects() {
+        const gamePointer = this.gameController.getGamePointer();
         const playerObject = this.createAndGetPlayerObject();
-        const localCarObject = new LocalCarObject(0, 0, 90, this.canvas);
+        const localCarObject = new LocalCarObject(0, 0, 90, this.canvas, gamePointer);
         localCarObject.setCenterPosition();
         localCarObject.setPlayerObject(playerObject);
         // Scene

--- a/static/js/services/game-loop-service.js
+++ b/static/js/services/game-loop-service.js
@@ -123,6 +123,7 @@ export class GameLoopService {
         this.gameFrame.getCurrentScreen()?.update(deltaTimeStamp);
         this.gameFrame.getNextScreen()?.update(deltaTimeStamp);
         this.gameFrame.getNotificationObject()?.update(deltaTimeStamp);
+        this.gamePointer.setPressed(false);
     }
     render() {
         this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);

--- a/static/js/services/game-loop-service.js
+++ b/static/js/services/game-loop-service.js
@@ -67,6 +67,8 @@ export class GameLoopService {
             this.gamePointer.setType(event.pointerType);
             this.gamePointer.setX(event.clientX);
             this.gamePointer.setY(event.clientY);
+            this.gamePointer.setInitialX(event.clientX);
+            this.gamePointer.setInitialY(event.clientY);
             this.gamePointer.setPressing(true);
         });
         window.addEventListener("pointerup", (event) => {


### PR DESCRIPTION
Related to #5

Update `JoystickObject` to use `GamePointer` for touch inputs and store initial x and y coordinates.

* Add `initialX` and `initialY` properties to `GamePointer` class in `src/models/game-pointer.ts`.
* Add `setInitialX`, `setInitialY`, `getInitialX`, and `getInitialY` methods to `GamePointer` class.
* Update `setPressed` method in `GamePointer` to set initial x and y coordinates.
* Remove touch event listeners and related methods from `JoystickObject` class in `src/objects/joystick-object.ts`.
* Use `GamePointer` class to handle touch inputs in `JoystickObject`.
* Update `updateJoystickPosition`, `calculateDistance`, `adjustPosition`, `calculateControlValues`, and `drawInitialTouchCircleBorder` methods in `JoystickObject` to use `GamePointer` state.
* Update `pointerdown` event listener in `GameLoopService` class in `src/services/game-loop-service.ts` to set initial x and y coordinates in `GamePointer`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/game/issues/5?shareId=4dcf5ba1-2a65-4074-b94e-7e5f2f8662bc).