### PR TITLE
Use game pointer class for gear stick controls

### DIFF
--- a/src/objects/gear-stick-object.ts
+++ b/src/objects/gear-stick-object.ts
@@ -1,4 +1,5 @@
 import { BaseGameObject } from "./base/base-game-object.js";
+import { GamePointer } from "../models/game-pointer.js";
 
 export class GearStickObject extends BaseGameObject {
   private readonly SIZE: number = 65; // Adjust size as needed
@@ -12,15 +13,18 @@ export class GearStickObject extends BaseGameObject {
   private active: boolean = false;
   private currentGear = "F";
 
-  constructor(private readonly canvas: HTMLCanvasElement) {
+  constructor(
+    private readonly canvas: HTMLCanvasElement,
+    private readonly gamePointer: GamePointer
+  ) {
     super();
     this.y = this.canvas.height - (this.SIZE + this.Y_OFFSET);
-    this.addTouchEventListeners();
     this.addKeyboardEventListeners();
   }
 
   public update(deltaTimeStamp: DOMHighResTimeStamp): void {
     // Implement update logic if required
+    this.handleTouchEvents();
   }
 
   public render(context: CanvasRenderingContext2D): void {
@@ -67,35 +71,18 @@ export class GearStickObject extends BaseGameObject {
     );
   }
 
-  private addTouchEventListeners(): void {
-    this.canvas.addEventListener(
-      "touchstart",
-      this.handleTouchStart.bind(this),
-      { passive: false },
-    );
+  private handleTouchEvents(): void {
+    if (this.gamePointer.isPressed()) {
+      const rect = this.canvas.getBoundingClientRect();
+      const touchX = this.gamePointer.getX() - rect.left;
+      const touchY = this.gamePointer.getY() - rect.top;
 
-    this.canvas.addEventListener("touchend", this.handleTouchEnd.bind(this), {
-      passive: true,
-    });
-  }
-
-  private handleTouchStart(event: TouchEvent): void {
-    const touch = event.touches[0];
-    if (!touch) return;
-
-    const rect = this.canvas.getBoundingClientRect();
-    const touchX = touch.clientX - rect.left;
-    const touchY = touch.clientY - rect.top;
-
-    if (this.isWithinGearStick(touchX, touchY)) {
-      this.active = true;
-    }
-  }
-
-  private handleTouchEnd(event: TouchEvent): void {
-    if (this.active) {
-      this.switchGear();
-      this.active = false;
+      if (this.isWithinGearStick(touchX, touchY)) {
+        this.active = true;
+        this.switchGear();
+      } else {
+        this.active = false;
+      }
     }
   }
 

--- a/src/objects/gear-stick-object.ts
+++ b/src/objects/gear-stick-object.ts
@@ -23,7 +23,6 @@ export class GearStickObject extends BaseGameObject {
   }
 
   public update(deltaTimeStamp: DOMHighResTimeStamp): void {
-    // Implement update logic if required
     this.handleTouchEvents();
   }
 
@@ -53,7 +52,7 @@ export class GearStickObject extends BaseGameObject {
       this.y + this.SIZE / 2, // y-coordinate of the center
       this.SIZE / 2, // radius
       0, // start angle
-      Math.PI * 2, // end angle
+      Math.PI * 2 // end angle
     );
     context.closePath();
     context.fill();
@@ -67,22 +66,23 @@ export class GearStickObject extends BaseGameObject {
     context.fillText(
       this.currentGear,
       this.x + this.SIZE / 2,
-      this.y + this.SIZE / 2 + 12,
+      this.y + this.SIZE / 2 + 12
     );
   }
 
   private handleTouchEvents(): void {
-    if (this.gamePointer.isPressed()) {
-      const rect = this.canvas.getBoundingClientRect();
-      const touchX = this.gamePointer.getX() - rect.left;
-      const touchY = this.gamePointer.getY() - rect.top;
+    const rect = this.canvas.getBoundingClientRect();
+    const touchX = this.gamePointer.getX() - rect.left;
+    const touchY = this.gamePointer.getY() - rect.top;
 
-      if (this.isWithinGearStick(touchX, touchY)) {
-        this.active = true;
+    if (this.isWithinGearStick(touchX, touchY)) {
+      this.active = true;
+
+      if (this.gamePointer.isPressed()) {
         this.switchGear();
-      } else {
-        this.active = false;
       }
+    } else {
+      this.active = false;
     }
   }
 

--- a/src/objects/local-car-object.ts
+++ b/src/objects/local-car-object.ts
@@ -16,7 +16,7 @@ export class LocalCarObject extends CarObject {
   ) {
     super(x, y, angle, false, canvas);
     this.joystickObject = new JoystickObject(canvas, gamePointer);
-    this.gearStickObject = new GearStickObject(canvas);
+    this.gearStickObject = new GearStickObject(canvas, gamePointer);
   }
 
   public update(deltaTimeStamp: DOMHighResTimeStamp): void {

--- a/static/js/objects/gear-stick-object.js
+++ b/static/js/objects/gear-stick-object.js
@@ -1,6 +1,7 @@
 import { BaseGameObject } from "./base/base-game-object.js";
 export class GearStickObject extends BaseGameObject {
     canvas;
+    gamePointer;
     SIZE = 65; // Adjust size as needed
     FILL_COLOR = "black"; // Change fill color to black
     FONT_SIZE = 36; // Adjust font size as needed
@@ -9,15 +10,16 @@ export class GearStickObject extends BaseGameObject {
     x = 30;
     active = false;
     currentGear = "F";
-    constructor(canvas) {
+    constructor(canvas, gamePointer) {
         super();
         this.canvas = canvas;
+        this.gamePointer = gamePointer;
         this.y = this.canvas.height - (this.SIZE + this.Y_OFFSET);
-        this.addTouchEventListeners();
         this.addKeyboardEventListeners();
     }
     update(deltaTimeStamp) {
         // Implement update logic if required
+        this.handleTouchEvents();
     }
     render(context) {
         this.drawCircle(context); // Modified to draw a circle
@@ -51,27 +53,17 @@ export class GearStickObject extends BaseGameObject {
         context.textAlign = "center";
         context.fillText(this.currentGear, this.x + this.SIZE / 2, this.y + this.SIZE / 2 + 12);
     }
-    addTouchEventListeners() {
-        this.canvas.addEventListener("touchstart", this.handleTouchStart.bind(this), { passive: false });
-        this.canvas.addEventListener("touchend", this.handleTouchEnd.bind(this), {
-            passive: true,
-        });
-    }
-    handleTouchStart(event) {
-        const touch = event.touches[0];
-        if (!touch)
-            return;
-        const rect = this.canvas.getBoundingClientRect();
-        const touchX = touch.clientX - rect.left;
-        const touchY = touch.clientY - rect.top;
-        if (this.isWithinGearStick(touchX, touchY)) {
-            this.active = true;
-        }
-    }
-    handleTouchEnd(event) {
-        if (this.active) {
-            this.switchGear();
-            this.active = false;
+    handleTouchEvents() {
+        if (this.gamePointer.isPressed()) {
+            const rect = this.canvas.getBoundingClientRect();
+            const touchX = this.gamePointer.getX() - rect.left;
+            const touchY = this.gamePointer.getY() - rect.top;
+            if (this.isWithinGearStick(touchX, touchY)) {
+                this.active = true;
+                this.switchGear();
+            } else {
+                this.active = false;
+            }
         }
     }
     isWithinGearStick(x, y) {

--- a/static/js/objects/gear-stick-object.js
+++ b/static/js/objects/gear-stick-object.js
@@ -18,7 +18,6 @@ export class GearStickObject extends BaseGameObject {
         this.addKeyboardEventListeners();
     }
     update(deltaTimeStamp) {
-        // Implement update logic if required
         this.handleTouchEvents();
     }
     render(context) {
@@ -42,7 +41,8 @@ export class GearStickObject extends BaseGameObject {
         this.y + this.SIZE / 2, // y-coordinate of the center
         this.SIZE / 2, // radius
         0, // start angle
-        Math.PI * 2);
+        Math.PI * 2 // end angle
+        );
         context.closePath();
         context.fill();
     }
@@ -54,16 +54,17 @@ export class GearStickObject extends BaseGameObject {
         context.fillText(this.currentGear, this.x + this.SIZE / 2, this.y + this.SIZE / 2 + 12);
     }
     handleTouchEvents() {
-        if (this.gamePointer.isPressed()) {
-            const rect = this.canvas.getBoundingClientRect();
-            const touchX = this.gamePointer.getX() - rect.left;
-            const touchY = this.gamePointer.getY() - rect.top;
-            if (this.isWithinGearStick(touchX, touchY)) {
-                this.active = true;
+        const rect = this.canvas.getBoundingClientRect();
+        const touchX = this.gamePointer.getX() - rect.left;
+        const touchY = this.gamePointer.getY() - rect.top;
+        if (this.isWithinGearStick(touchX, touchY)) {
+            this.active = true;
+            if (this.gamePointer.isPressed()) {
                 this.switchGear();
-            } else {
-                this.active = false;
             }
+        }
+        else {
+            this.active = false;
         }
     }
     isWithinGearStick(x, y) {

--- a/static/js/objects/local-car-object.js
+++ b/static/js/objects/local-car-object.js
@@ -7,7 +7,7 @@ export class LocalCarObject extends CarObject {
     constructor(x, y, angle, canvas, gamePointer) {
         super(x, y, angle, false, canvas);
         this.joystickObject = new JoystickObject(canvas, gamePointer);
-        this.gearStickObject = new GearStickObject(canvas);
+        this.gearStickObject = new GearStickObject(canvas, gamePointer);
     }
     update(deltaTimeStamp) {
         this.handleControls();


### PR DESCRIPTION
Related to #7

Update gear stick controls to use `GamePointer` class.

* **GearStickObject class:**
  - Modify constructor to accept `GamePointer` instance.
  - Remove `addTouchEventListeners` method.
  - Add `handleTouchEvents` method to use `GamePointer` for x, y, and pressed state.
  - Update `handleTouchStart` and `handleTouchEnd` methods to use `GamePointer`.

* **LocalCarObject class:**
  - Pass `GamePointer` instance to `GearStickObject` constructor.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/game/issues/7?shareId=e22f492b-c01d-416b-be14-d1c4c3f39a9b).