### PR TITLE
Move pointer event listeners to GamePointer class

### DIFF
--- a/src/models/game-pointer.ts
+++ b/src/models/game-pointer.ts
@@ -79,4 +79,27 @@ export class GamePointer {
     this.pressing = false;
     this.pressed = false;
   }
+
+  public addEventListeners(): void {
+    window.addEventListener("pointermove", (event) => {
+      this.setX(event.clientX);
+      this.setY(event.clientY);
+    });
+
+    window.addEventListener("pointerdown", (event) => {
+      this.setType(event.pointerType as PointerType);
+      this.setX(event.clientX);
+      this.setY(event.clientY);
+      this.setInitialX(event.clientX);
+      this.setInitialY(event.clientY);
+      this.setPressing(true);
+    });
+
+    window.addEventListener("pointerup", (event) => {
+      this.setX(event.clientX);
+      this.setY(event.clientY);
+      this.setPressing(false);
+      this.setPressed(true);
+    });
+  }
 }

--- a/src/services/game-loop-service.ts
+++ b/src/services/game-loop-service.ts
@@ -71,8 +71,8 @@ export class GameLoopService {
 
   private addEventListeners(): void {
     this.addWindowEventListeners();
-    this.addPointerEventListeners();
     this.addCustomEventListeners();
+    this.gamePointer.addEventListeners();
     this.gameKeyboard.addEventListeners();
   }
 
@@ -80,29 +80,6 @@ export class GameLoopService {
     window.addEventListener("resize", () => {
       this.canvas.width = document.body.clientWidth;
       this.canvas.height = document.body.clientHeight;
-    });
-  }
-
-  private addPointerEventListeners(): void {
-    window.addEventListener("pointermove", (event) => {
-      this.gamePointer.setX(event.clientX);
-      this.gamePointer.setY(event.clientY);
-    });
-
-    window.addEventListener("pointerdown", (event) => {
-      this.gamePointer.setType(event.pointerType as PointerType);
-      this.gamePointer.setX(event.clientX);
-      this.gamePointer.setY(event.clientY);
-      this.gamePointer.setInitialX(event.clientX);
-      this.gamePointer.setInitialY(event.clientY);
-      this.gamePointer.setPressing(true);
-    });
-
-    window.addEventListener("pointerup", (event) => {
-      this.gamePointer.setX(event.clientX);
-      this.gamePointer.setY(event.clientY);
-      this.gamePointer.setPressing(false);
-      this.gamePointer.setPressed(true);
     });
   }
 

--- a/static/js/models/game-pointer.js
+++ b/static/js/models/game-pointer.js
@@ -59,4 +59,24 @@ export class GamePointer {
         this.pressing = false;
         this.pressed = false;
     }
+    addEventListeners() {
+        window.addEventListener("pointermove", (event) => {
+            this.setX(event.clientX);
+            this.setY(event.clientY);
+        });
+        window.addEventListener("pointerdown", (event) => {
+            this.setType(event.pointerType);
+            this.setX(event.clientX);
+            this.setY(event.clientY);
+            this.setInitialX(event.clientX);
+            this.setInitialY(event.clientY);
+            this.setPressing(true);
+        });
+        window.addEventListener("pointerup", (event) => {
+            this.setX(event.clientX);
+            this.setY(event.clientY);
+            this.setPressing(false);
+            this.setPressed(true);
+        });
+    }
 }

--- a/static/js/services/game-loop-service.js
+++ b/static/js/services/game-loop-service.js
@@ -51,34 +51,14 @@ export class GameLoopService {
     }
     addEventListeners() {
         this.addWindowEventListeners();
-        this.addPointerEventListeners();
         this.addCustomEventListeners();
+        this.gamePointer.addEventListeners();
         this.gameKeyboard.addEventListeners();
     }
     addWindowEventListeners() {
         window.addEventListener("resize", () => {
             this.canvas.width = document.body.clientWidth;
             this.canvas.height = document.body.clientHeight;
-        });
-    }
-    addPointerEventListeners() {
-        window.addEventListener("pointermove", (event) => {
-            this.gamePointer.setX(event.clientX);
-            this.gamePointer.setY(event.clientY);
-        });
-        window.addEventListener("pointerdown", (event) => {
-            this.gamePointer.setType(event.pointerType);
-            this.gamePointer.setX(event.clientX);
-            this.gamePointer.setY(event.clientY);
-            this.gamePointer.setInitialX(event.clientX);
-            this.gamePointer.setInitialY(event.clientY);
-            this.gamePointer.setPressing(true);
-        });
-        window.addEventListener("pointerup", (event) => {
-            this.gamePointer.setX(event.clientX);
-            this.gamePointer.setY(event.clientY);
-            this.gamePointer.setPressing(false);
-            this.gamePointer.setPressed(true);
         });
     }
     addCustomEventListeners() {


### PR DESCRIPTION
Fixes #12

Move pointer event listeners to `GamePointer` class.

* Add `addEventListeners` method to `GamePointer` class in `src/models/game-pointer.ts` to handle pointer event listeners.
* Remove `addPointerEventListeners` method from `GameLoopService` class in `src/services/game-loop-service.ts`.
* Call `gamePointer.addEventListeners` method in `addEventListeners` method of `GameLoopService` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/game/issues/12?shareId=c144719d-5264-4ddd-b29e-da8aac32b1da).