### PR TITLE
Add getters to get total objects count and loaded objects count

### DIFF
--- a/src/screens/base/base-game-screen.ts
+++ b/src/screens/base/base-game-screen.ts
@@ -76,6 +76,17 @@ export class BaseGameScreen implements GameScreen {
     console.log(`Transition to ${this.constructor.name} finished`);
   }
 
+  public getTotalObjectsCount(): number {
+    return this.sceneObjects.length + this.uiObjects.length;
+  }
+
+  public getLoadedObjectsCount(): number {
+    return (
+      this.sceneObjects.filter((object) => object.hasLoaded()).length +
+      this.uiObjects.filter((object) => object.hasLoaded()).length
+    );
+  }
+
   private setDebugToChildObjects(): void {
     const debug = this.gameController.isDebugging();
 


### PR DESCRIPTION
Fixes #16

Add getters to `BaseGameScreen` class to retrieve total objects count and loaded objects count.

* Add `getTotalObjectsCount` method to return the sum of `sceneObjects` and `uiObjects` lengths.
* Add `getLoadedObjectsCount` method to return the count of loaded objects in `sceneObjects` and `uiObjects`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/game/issues/16?shareId=f6ce877c-a972-4c3a-b147-82d237526c8e).