### PR TITLE
Add glow effect when ball is inactive

### DIFF
--- a/src/objects/ball-object.ts
+++ b/src/objects/ball-object.ts
@@ -89,6 +89,14 @@ export class BallObject extends BaseDynamicCollidableGameObject {
     context.fill();
     context.closePath();
 
+    // Add glow effect if inactive
+    if (this.inactive) {
+      context.shadowColor = "rgba(255, 255, 255, 0.8)";
+      context.shadowBlur = 20;
+      context.shadowOffsetX = 0;
+      context.shadowOffsetY = 0;
+    }
+
     // Restore the context state
     context.restore();
 
@@ -113,7 +121,11 @@ export class BallObject extends BaseDynamicCollidableGameObject {
 
   private handleInactiveState(deltaTimeStamp: DOMHighResTimeStamp) {
     if (this.inactive) {
-      // TODO: glow effect
+      this.elapsedInactiveMilliseconds += deltaTimeStamp;
+      if (this.elapsedInactiveMilliseconds >= 1000) {
+        this.elapsedInactiveMilliseconds = 0;
+        this.radius = this.RADIUS + 5; // Increase radius to create a glow effect
+      }
     }
   }
 

--- a/static/js/objects/ball-object.js
+++ b/static/js/objects/ball-object.js
@@ -64,6 +64,13 @@ export class BallObject extends BaseDynamicCollidableGameObject {
         context.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
         context.fill();
         context.closePath();
+        // Add glow effect if inactive
+        if (this.inactive) {
+            context.shadowColor = "rgba(255, 255, 255, 0.8)";
+            context.shadowBlur = 20;
+            context.shadowOffsetX = 0;
+            context.shadowOffsetY = 0;
+        }
         // Restore the context state
         context.restore();
         if (this.debug) {
@@ -78,7 +85,11 @@ export class BallObject extends BaseDynamicCollidableGameObject {
     }
     handleInactiveState(deltaTimeStamp) {
         if (this.inactive) {
-            // TODO: glow effect
+            this.elapsedInactiveMilliseconds += deltaTimeStamp;
+            if (this.elapsedInactiveMilliseconds >= 1000) {
+                this.elapsedInactiveMilliseconds = 0;
+                this.radius = this.RADIUS + 5; // Increase radius to create a glow effect
+            }
         }
     }
     applyFriction() {


### PR DESCRIPTION
Fixes #19

Add a glow effect to the ball when it is inactive.

* **src/objects/ball-object.ts**
  - Add logic to the `handleInactiveState` method to increase the ball's radius to create a glow effect when it is inactive.
  - Update the `render` method to include a glow effect when the ball is inactive by setting shadow properties on the context.

* **static/js/objects/ball-object.js**
  - Add logic to the `handleInactiveState` method to increase the ball's radius to create a glow effect when it is inactive.
  - Update the `render` method to include a glow effect when the ball is inactive by setting shadow properties on the context.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/game/issues/19?shareId=d5636b35-2071-4550-a9df-20137d26474d).