### PR TITLE
Allow keyboard controls if touch is not being used

### DIFF
--- a/src/objects/joystick-object.ts
+++ b/src/objects/joystick-object.ts
@@ -25,12 +25,9 @@ export class JoystickObject extends BaseGameObject {
     if (this.gamePointer.isTouch()) {
       this.handleGamePointerEvents();
       this.updateJoystickPosition();
-
-      if (this.debug) {
-        this.updateControlValues();
+      if (this.debug && !this.gamePointer.isPressing()) {
+        this.handleKeyboardEvents();
       }
-    } else {
-      this.updateControlValues();
     }
   }
 
@@ -151,7 +148,7 @@ export class JoystickObject extends BaseGameObject {
     context.closePath();
   }
 
-  private updateControlValues() {
+  private handleKeyboardEvents() {
     const pressedKeys = this.gameKeyboard.getPressedKeys();
 
     const isArrowUpPressed = pressedKeys.has("ArrowUp") || pressedKeys.has("w");

--- a/static/js/objects/joystick-object.js
+++ b/static/js/objects/joystick-object.js
@@ -20,12 +20,9 @@ export class JoystickObject extends BaseGameObject {
         if (this.gamePointer.isTouch()) {
             this.handleGamePointerEvents();
             this.updateJoystickPosition();
-            if (this.debug) {
-                this.updateControlValues();
+            if (this.debug && !this.gamePointer.isPressing()) {
+                this.handleKeyboardEvents();
             }
-        }
-        else {
-            this.updateControlValues();
         }
     }
     render(context) {
@@ -107,7 +104,7 @@ export class JoystickObject extends BaseGameObject {
         context.restore();
         context.closePath();
     }
-    updateControlValues() {
+    handleKeyboardEvents() {
         const pressedKeys = this.gameKeyboard.getPressedKeys();
         const isArrowUpPressed = pressedKeys.has("ArrowUp") || pressedKeys.has("w");
         const isArrowDownPressed = pressedKeys.has("ArrowDown") || pressedKeys.has("s");


### PR DESCRIPTION
Fixes #21

Update joystick object update logic to handle keyboard controls when touch is not being used

* Rename `updateControlValues` method to `handleKeyboardEvents`.
* Update `update` method to call `handleKeyboardEvents` when debug is true and touch is not being pressed.
* Update `update` method to call `handleGamePointerEvents` and `updateJoystickPosition` when the game pointer is touch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/game/issues/21?shareId=b9b43fea-8336-4393-b1c8-7c6a80ab7667).